### PR TITLE
If current page exceed total count returns last valid page

### DIFF
--- a/src/LightQuery.EntityFrameworkCore/AsyncLightQueryAttribute.cs
+++ b/src/LightQuery.EntityFrameworkCore/AsyncLightQueryAttribute.cs
@@ -46,11 +46,19 @@ namespace LightQuery.EntityFrameworkCore
         {
             var queryOptions = queryContainer.QueryOptions;
             var queryable = queryContainer.Queryable;
+
+            // FIXME : If it is necessary, we can move to another methot with proper parameters
+            var totalCount = await queryable.Cast<object>().CountAsync();
+            if (totalCount <= ((queryOptions.Page - 1) * queryOptions.PageSize))
+            {
+                queryOptions.Page = (int)System.Math.Ceiling((decimal)totalCount / queryOptions.PageSize);
+            }
+
             return new PaginationResult<object>
             {
                 Page = queryOptions.Page,
                 PageSize = queryOptions.PageSize,
-                TotalCount = await queryable.Cast<object>().CountAsync(),
+                TotalCount = totalCount,
                 Data = await queryable.Cast<object>().Skip((queryOptions.Page - 1) * queryOptions.PageSize).Take(queryOptions.PageSize).ToListAsync()
             };
         }

--- a/src/LightQuery/LightQueryAttribute.cs
+++ b/src/LightQuery/LightQueryAttribute.cs
@@ -39,11 +39,19 @@ namespace LightQuery
         {
             var queryOptions = queryContainer.QueryOptions;
             var queryable = queryContainer.Queryable;
+
+            // FIXME : If it is necessary, we can move to another methot with proper parameters
+            var totalCount = queryable.Cast<object>().Count();
+            if (totalCount <= ((queryOptions.Page - 1) * queryOptions.PageSize))
+            {
+                queryOptions.Page = (int)System.Math.Ceiling((decimal)totalCount / queryOptions.PageSize);
+            }
+
             return new PaginationResult<object>
             {
                 Page = queryOptions.Page,
                 PageSize = queryOptions.PageSize,
-                TotalCount = queryable.Cast<object>().Count(),
+                TotalCount = totalCount,
                 Data = queryable.Cast<object>().Skip((queryOptions.Page - 1) * queryOptions.PageSize).Take(queryOptions.PageSize).ToList()
             };
         }

--- a/test/LightQuery.EntityFrameworkCore.Tests.Integration/ControllerTests/AsyncPaginatedLightQueryControllerTests.cs
+++ b/test/LightQuery.EntityFrameworkCore.Tests.Integration/ControllerTests/AsyncPaginatedLightQueryControllerTests.cs
@@ -194,6 +194,18 @@ namespace LightQuery.EntityFrameworkCore.Tests.Integration.ControllerTests
         }
 
         [Fact]
+        public async Task IfPageAndPageSizeExceedTotalCountReturnsLastValidPageAndRecord()
+        {
+            var url = "AsyncPaginatedLightQuery?sort=userName&page=4&pageSize=5";
+            var pagedResult = await GetResponse<PaginationResult<User>>(url);
+            Assert.Equal(10, pagedResult.TotalCount);
+
+            Assert.Equal(2, pagedResult.Page);
+            Assert.Equal(5, pagedResult.PageSize);
+            Assert.Equal(5, pagedResult.Data.Count);
+        }
+
+        [Fact]
         public async Task AppliesDefaultSortWithoutClientSortParameter()
         {
             var url = "AsyncPaginatedLightQueryWithDefaultSort";


### PR DESCRIPTION
### Request;
Page : 4
PageSize : 5

### After Reqest;
TotalCount : 10

Assume that case happens!
[pagesize * (page - 1)] => 5 * (4-1) => 15 
Skip 15 records and gets after that

**Old Response** Gives us;
page : 4
pageSize : 5
totalCount: 10
data : []  <<< Empty

**New Response** Gives us
page : **2** <<< Last valid page
pageSize : 5
totalCount : 10
data : [..5..] <<< Not Empty! filled with last page records (Showing 6-10 records)